### PR TITLE
PHP 5.4 Strict Standards + Plugin Compatibility

### DIFF
--- a/custom-javascript-editor.php
+++ b/custom-javascript-editor.php
@@ -178,7 +178,8 @@ class Custom_Javascript_Editor {
 			'post_status' => 'publish',
 		);
 
-		if ( $post = array_shift( get_posts( $args ) ) )
+		$posts = get_posts( $args );
+		if ( $post = array_shift( $posts ) )
 			return get_object_vars( $post );
 		
 		return false;
@@ -194,7 +195,8 @@ class Custom_Javascript_Editor {
 		if ( empty( $revisions ) )
 			return $js;
 
-		return get_object_vars( array_shift( $revisions ) );
+		$revision = array_shift( $revisions );
+		return get_object_vars( $revision );
 	}
 
 	function save_revision( $js, $is_preview = false ) {
@@ -294,8 +296,9 @@ class Custom_Javascript_Editor {
 	 */
 	function action_wp_enqueue_scripts() {
 		$enqueue_scripts = get_option( self::enqueue_option, array() );
-		foreach( $enqueue_scripts as $script_identifier ) {
-			$script = array_pop( wp_filter_object_list( $this->available_scripts, array( 'identifier' => $script_identifier ) ) );
+		foreach ( $enqueue_scripts as $script_identifier ) {
+			$matching_scripts = wp_filter_object_list( $this->available_scripts, array( 'identifier' => $script_identifier ) );
+			$script = array_pop( $matching_scripts );
 			// @todo Support for dependencies and specifying the path
 			if ( ! empty( $script ) ) {
 				$source = ( ! empty( $script['source'] ) ) ? $script['source'] : null;

--- a/custom-javascript-editor.php
+++ b/custom-javascript-editor.php
@@ -195,8 +195,7 @@ class Custom_Javascript_Editor {
 		if ( empty( $revisions ) )
 			return $js;
 
-		$revision = array_shift( $revisions );
-		return get_object_vars( $revision );
+		return get_object_vars( array_shift( $revisions ) );
 	}
 
 	function save_revision( $js, $is_preview = false ) {

--- a/jslint/initui.js
+++ b/jslint/initui.js
@@ -3,7 +3,7 @@ jQuery(document).ready(function($) {
 	    $errors = $errorsdiv.find('.errors'),
 
 	    // Run the linter
-	    input = $('textarea').val(),
+	    input = $('#cje-javascript').val(),
 	    options = {'predef': ['jQuery']},
 	    result = JSLINT(input, options),
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, betzster, danielbachhuber
 Tags: javascript
 Requires at least: 3.4
-Tested up to: 3.5.1
+Tested up to: 3.8
 Stable tag: 1.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -30,6 +30,9 @@ If you'd like to check out the code and contribute, [join us on GitHub](https://
 
 == Upgrade Notice ==
 
+= 1.3 =
+* Plugin & PHP 5.4 Strict mode compatibility
+
 = 1.2 =
 * Don't output custom javascript on the login page, thanks Carl Danley.
 
@@ -40,6 +43,10 @@ If you'd like to check out the code and contribute, [join us on GitHub](https://
 Enqueue any bundled JavaScript libraries on the frontend for use. Register your own with the 'cje_available_scripts' filter.
 
 == Changelog ==
+
+= 1.3 (Dec, 2013 ) =
+* PHP 5.4 Strict Standards compatibility
+* Compatibility with other plugins that include a <textarea> on the page, previously this may have caused JSLint not to operate.
 
 = 1.1 (Nov. 19, 2012) =
 * The editor has a syntax highlighter with configurable themes.


### PR DESCRIPTION
Got a report of a few issues with this plugin, namely, that PHP Strict Standards warnings were being picked up when running in WP_DEBUG mode, or the servers error_reporting is higher than normal.

In addition, while testing, I found that having multiple <textarea>'s on a page would confuse the JSLint Javascript.
